### PR TITLE
chore: ファイル命名規則適用のため、eslint-plugin-validate-filenameを追加

### DIFF
--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -1,16 +1,88 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
+import validateFilename from "eslint-plugin-validate-filename";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const compat = new FlatCompat({
-  baseDirectory: __dirname,
+  baseDirectory: __dirname
 });
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    plugins: {
+      "validate-filename": validateFilename
+    },
+    rules: {
+      "validate-filename/naming-rules": [
+        "error",
+        {
+          rules: [
+            {
+              case: "kebab",
+              target: "**/app/**",
+              patterns: "^(page|layout|loading|error|not-found|route|template).tsx$"
+            },
+            {
+              case: "pascal",
+              target: "**/components/**"
+            },
+            {
+              case: "camel",
+              target: "**/hooks/**",
+              patterns: "^use"
+            },
+            {
+              case: "camel",
+              target: "**/const/**"
+            },
+            {
+              case: "camel",
+              target: "**/types/**"
+            },
+            {
+              case: "camel",
+              target: "**/lib/**"
+            }
+          ]
+        }
+      ],
+      "validate-filename/limit-extensions": [
+        "error",
+        {
+          rules: [
+            {
+              target: "**/app/**",
+              extensions: [".tsx"]
+            },
+            {
+              target: "**/components/**",
+              extensions: [".tsx"]
+            },
+            {
+              target: "**/hooks/**",
+              extensions: [".ts", ".tsx"]
+            },
+            {
+              target: "**/const/**",
+              extensions: [".ts"]
+            },
+            {
+              target: "**/types/**",
+              extensions: [".ts"]
+            },
+            {
+              target: "**/lib/**",
+              extensions: [".ts"]
+            }
+          ]
+        }
+      ]
+    }
+  }
 ];
 
 export default eslintConfig;

--- a/src/next.config.ts
+++ b/src/next.config.ts
@@ -2,6 +2,12 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  eslint: {
+    // ビルド時にESLintを実行する対象ディレクトリ
+    dirs: ["app", "components", "hooks", "lib"],
+    // ESLintのエラーがある場合、ビルドを失敗させる（これが重要な設定）
+    ignoreDuringBuilds: false
+  }
 };
 
 export default nextConfig;

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -19,6 +19,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.2.0",
+        "eslint-plugin-validate-filename": "^1.0.0",
         "prettier": "^3.5.3",
         "typescript": "^5"
       }
@@ -2295,6 +2296,22 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-validate-filename": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-validate-filename/-/eslint-plugin-validate-filename-1.0.0.tgz",
+      "integrity": "sha512-ufA6gzfxNTSP7YH6PTteUqKEbAdAVrCCrUFtYsqRkr2Ny4yP6rVpay51tE0JTXTGnZyx7u4QhjvEdZGUdsnyvA==",
+      "dev": true,
+      "dependencies": {
+        "micromatch": "^4.0.5",
+        "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/src/package.json
+++ b/src/package.json
@@ -21,6 +21,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.2.0",
+    "eslint-plugin-validate-filename": "^1.0.0",
     "prettier": "^3.5.3",
     "typescript": "^5"
   }


### PR DESCRIPTION
ファイルの命名規則を制限するためのライブラリとルールを追加する